### PR TITLE
Changed mime to webm in MicrophoneRecorder.js

### DIFF
--- a/src/libs/MicrophoneRecorder.js
+++ b/src/libs/MicrophoneRecorder.js
@@ -69,7 +69,7 @@ export class MicrophoneRecorder {
   }
 
   onStop(evt) {
-    const blob = new Blob(chunks, { 'type' : 'audio/mp3' });
+    const blob = new Blob(chunks, { 'type' : 'audio/webm' });
     chunks = [];
 
     const blobObject =  {


### PR DESCRIPTION
After recording, I've uploading blob to a server. Uploaded blob didn't work if it has .mp3 extension. So, I've determine that right format for blob is webm.